### PR TITLE
Remove event image (if existing) from storage complete

### DIFF
--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/Habit.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/Habit.java
@@ -114,5 +114,11 @@ public class Habit {
 
     public void setScore(int newScore) { this.score = newScore; }
 
+    public void setHabitEvents(ArrayList<HabitEvent> habitEvents) {
+        this.habitEvents = habitEvents;
+    }
+    public ArrayList<HabitEvent> getHabitEvents(){
+        return habitEvents;
+    }
 }
 

--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/SharedHelper.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/SharedHelper.java
@@ -1,0 +1,81 @@
+package com.CMPUT301F21T19.habitappt;
+
+import android.util.Log;
+
+import androidx.annotation.NonNull;
+
+import com.google.android.gms.tasks.OnFailureListener;
+import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.firebase.firestore.FirebaseFirestore;
+import com.google.firebase.storage.FirebaseStorage;
+import com.google.firebase.storage.StorageReference;
+
+/**
+ * Class that can be used to share methods and instance variables necessary between classes
+ */
+class SharedHelper {
+    /**
+     * deletes image given storage instance
+     * @param id
+     * @param storage
+     */
+    public static void deleteImage(String id, FirebaseStorage storage) {
+        //remove image from firestore storage after deleting event
+        StorageReference ref = storage.getReferenceFromUrl("gs://habitappt.appspot.com/default_user/" + id + ".jpg");
+        ref.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
+            @Override
+            public void onSuccess(Void unused) {
+                Log.d("STORAGE", "onSuccess: deleted image");
+            }
+        }).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                Log.d("STORAGE", "onFailure: could not delete image");
+            }
+        });
+    }
+
+    /**
+     * deletes event from db given the habit, event, and db instance
+     * @param event
+     * @param habit
+     * @param db
+     */
+    public static void removeEvent(HabitEvent event, Habit habit, FirebaseFirestore db){
+        db.collection("Default User")
+                .document(String.valueOf(habit.getId()))
+                .collection("Event Collection")
+                .document(String.valueOf(event.getId()))
+                .delete()
+                .addOnSuccessListener(new OnSuccessListener<Void>() {
+                    @Override
+                    public void onSuccess(Void unused) {
+                        Log.i("data","event has been removed succesfully!");
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        Log.i("data","event has not been removed succesfully" + e.toString());
+                    }
+                });
+    }
+
+    public static void removeHabit(Habit habit, FirebaseFirestore db){
+        db.collection("Default User")
+                .document(String.valueOf(habit.getId()))
+                .delete()
+                .addOnSuccessListener(new OnSuccessListener<Void>() {
+                    @Override
+                    public void onSuccess(Void unused) {
+                        Log.i("data","Data has been removed succesfully!");
+                    }
+                })
+                .addOnFailureListener(new OnFailureListener() {
+                    @Override
+                    public void onFailure(@NonNull Exception e) {
+                        Log.i("data","Data could not be removed" + e.toString());
+                    }
+                });
+    }
+}

--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
@@ -22,9 +22,12 @@ import androidx.annotation.Nullable;
 import androidx.fragment.app.DialogFragment;
 import androidx.fragment.app.FragmentManager;
 
+import com.google.android.gms.tasks.OnCompleteListener;
 import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
+import com.google.android.gms.tasks.Task;
 import com.google.firebase.firestore.DocumentReference;
+import com.google.firebase.firestore.DocumentSnapshot;
 import com.google.firebase.firestore.FirebaseFirestore;
 import com.google.firebase.storage.FirebaseStorage;
 import com.google.firebase.storage.StorageReference;
@@ -151,6 +154,7 @@ public class edit_event extends DialogFragment {
                 .setNegativeButton(removeTextTitle, new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
+                        //remove event from firestore database
                         getChildFragmentManager().popBackStack("vieeevent", FragmentManager.POP_BACK_STACK_INCLUSIVE);
                         db.collection("Default User")
                                 .document(String.valueOf(THIS.habit.getId()))
@@ -169,6 +173,20 @@ public class edit_event extends DialogFragment {
                                         Log.i("data","event has not been removed succesfully" + e.toString());
                                     }
                                 });
+
+                        //remove image from firestore storage after deleting event
+                        StorageReference ref = storage.getReferenceFromUrl("gs://habitappt.appspot.com/default_user/" + event.getId() + ".jpg");
+                        ref.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
+                            @Override
+                            public void onSuccess(Void unused) {
+                                Log.d("STORAGE", "onSuccess: deleted image");
+                            }
+                        }).addOnFailureListener(new OnFailureListener() {
+                            @Override
+                            public void onFailure(@NonNull Exception e) {
+                                Log.d("STORAGE", "onFailure: could not delete image");
+                            }
+                        });
                     }
                 })
                 .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {

--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
@@ -175,18 +175,7 @@ public class edit_event extends DialogFragment {
                                 });
 
                         //remove image from firestore storage after deleting event
-                        StorageReference ref = storage.getReferenceFromUrl("gs://habitappt.appspot.com/default_user/" + event.getId() + ".jpg");
-                        ref.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
-                            @Override
-                            public void onSuccess(Void unused) {
-                                Log.d("STORAGE", "onSuccess: deleted image");
-                            }
-                        }).addOnFailureListener(new OnFailureListener() {
-                            @Override
-                            public void onFailure(@NonNull Exception e) {
-                                Log.d("STORAGE", "onFailure: could not delete image");
-                            }
-                        });
+                        deleteImage(event.getId());
                     }
                 })
                 .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {
@@ -416,5 +405,21 @@ public class edit_event extends DialogFragment {
 
 
         }
+    }
+
+    public void deleteImage(String id){
+        //remove image from firestore storage after deleting event
+        StorageReference ref = storage.getReferenceFromUrl("gs://habitappt.appspot.com/default_user/" + id + ".jpg");
+        ref.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
+            @Override
+            public void onSuccess(Void unused) {
+                Log.d("STORAGE", "onSuccess: deleted image");
+            }
+        }).addOnFailureListener(new OnFailureListener() {
+            @Override
+            public void onFailure(@NonNull Exception e) {
+                Log.d("STORAGE", "onFailure: could not delete image");
+            }
+        });
     }
 }

--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
@@ -156,26 +156,10 @@ public class edit_event extends DialogFragment {
                     public void onClick(DialogInterface dialogInterface, int i) {
                         //remove event from firestore database
                         getChildFragmentManager().popBackStack("vieeevent", FragmentManager.POP_BACK_STACK_INCLUSIVE);
-                        db.collection("Default User")
-                                .document(String.valueOf(THIS.habit.getId()))
-                                .collection("Event Collection")
-                                .document(String.valueOf(THIS.event.getId()))
-                                .delete()
-                                .addOnSuccessListener(new OnSuccessListener<Void>() {
-                                    @Override
-                                    public void onSuccess(Void unused) {
-                                        Log.i("data","event has been removed succesfully!");
-                                    }
-                                })
-                                .addOnFailureListener(new OnFailureListener() {
-                                    @Override
-                                    public void onFailure(@NonNull Exception e) {
-                                        Log.i("data","event has not been removed succesfully" + e.toString());
-                                    }
-                                });
+
 
                         //remove image from firestore storage after deleting event
-                        deleteImage(event.getId());
+                        SharedHelper.deleteImage(event.getId(), storage);
                     }
                 })
                 .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {
@@ -406,20 +390,6 @@ public class edit_event extends DialogFragment {
 
         }
     }
-
-    public void deleteImage(String id){
-        //remove image from firestore storage after deleting event
-        StorageReference ref = storage.getReferenceFromUrl("gs://habitappt.appspot.com/default_user/" + id + ".jpg");
-        ref.delete().addOnSuccessListener(new OnSuccessListener<Void>() {
-            @Override
-            public void onSuccess(Void unused) {
-                Log.d("STORAGE", "onSuccess: deleted image");
-            }
-        }).addOnFailureListener(new OnFailureListener() {
-            @Override
-            public void onFailure(@NonNull Exception e) {
-                Log.d("STORAGE", "onFailure: could not delete image");
-            }
-        });
-    }
 }
+
+

--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/view_habit.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/view_habit.java
@@ -67,7 +67,7 @@ public class view_habit extends Fragment {
     ListView eventListView;
     SwipeMenuListView eventSwipeListView;
     ArrayAdapter<HabitEvent> eventAdapter;
-    ArrayList<HabitEvent> eventDataList;
+//    protected ArrayList<HabitEvent> eventDataList;
 
     SwipeMenuItem deleteItem;
     SwipeMenuItem editItem;
@@ -133,8 +133,8 @@ public class view_habit extends Fragment {
 
         //new
         eventSwipeListView = view.findViewById(R.id.event_list);
-        eventDataList = new ArrayList<>();
-        eventAdapter = new EventList(getContext(), eventDataList);
+        habit.setHabitEvents(new ArrayList<>());
+        eventAdapter = new EventList(getContext(), habit.getHabitEvents());
         eventSwipeListView.setAdapter(eventAdapter);
 
         SwipeMenuCreator creator = new SwipeMenuCreator() {
@@ -266,7 +266,7 @@ public class view_habit extends Fragment {
             @Override
             public void onEvent(@Nullable QuerySnapshot queryDocumentSnapshots, @Nullable FirebaseFirestoreException error) {
 
-                eventDataList.clear();
+                habit.getHabitEvents().clear();
 
                 int i = 0;
 
@@ -276,9 +276,10 @@ public class view_habit extends Fragment {
                     String comments = (String) doc.getData().get("comments");
                     Long eventDate = (Long) doc.getData().get("eventDate");
 
-                    eventDataList.add(new HabitEvent(comments, eventDate, habit, id));
+                    HabitEvent newEvent = new HabitEvent(comments, eventDate, habit, id);
 
-
+                    //adding to habitEventsList
+                    habit.getHabitEvents().add(newEvent);
 
                     if((Long) doc.getData().get("eventImg") != 0){
 
@@ -293,7 +294,7 @@ public class view_habit extends Fragment {
                                 final int index = finalI;
                                 Bitmap bitMapImg = BitmapFactory.decodeByteArray(bytes,0,bytes.length);
 
-                                eventDataList.get(index).setImg(bitMapImg);
+                                habit.getHabitEvents().get(index).setImg(bitMapImg);
                                 eventAdapter.notifyDataSetChanged();
 
 


### PR DESCRIPTION
Edited edit_event fragment to delete event image associated to habit (if existing) from firestore storage when remove selected, not just within database.

