### PR TITLE
fixed event not deleting when delete button is pressed

### DIFF
--- a/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
+++ b/app/src/main/java/com/CMPUT301F21T19/habitappt/edit_event.java
@@ -155,11 +155,12 @@ public class edit_event extends DialogFragment {
                     @Override
                     public void onClick(DialogInterface dialogInterface, int i) {
                         //remove event from firestore database
-                        getChildFragmentManager().popBackStack("vieeevent", FragmentManager.POP_BACK_STACK_INCLUSIVE);
+                        getChildFragmentManager().popBackStack("viewevent", FragmentManager.POP_BACK_STACK_INCLUSIVE);
 
 
                         //remove image from firestore storage after deleting event
                         SharedHelper.deleteImage(event.getId(), storage);
+                        SharedHelper.removeEvent(event,habit,db);
                     }
                 })
                 .setPositiveButton("Confirm", new DialogInterface.OnClickListener() {


### PR DESCRIPTION
both image and event are deleted upon clicking the delete button on a habit event now.
fixes US 02.06.01